### PR TITLE
feat: added concurrency safe capability to stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This is a code challenge for Stack in Go. 
 
-The first goal is to implement a simple stack in Go.
+- [x] The first goal is to implement a simple stack in Go. 
 
-Second goal is to implement a simple stack in Go that safe for concurrency.
+- [x] Second goal is to implement a simple stack in Go that safe for concurrency.
 
 ## Requirements
 
@@ -21,5 +21,5 @@ go run main.go
 ## How to test
 
 ```Bash
-go test -v
+go test -v -race
 ```

--- a/main.go
+++ b/main.go
@@ -1,50 +1,75 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"sync"
+)
 
 type Stack struct {
 	items []interface{}
+	rwmu  sync.RWMutex
 }
 
 // IsEmpty returns true if the stack is empty
 func (s *Stack) IsEmpty() (bool, int) {
-	if len(s.items) == 0 {
+
+	l := 0
+	s.rwmu.RLock()
+	l = len(s.items)
+	defer s.rwmu.RUnlock()
+
+	if l == 0 {
 		return true, 0
 	}
 
-	return false, len(s.items)
+	return false, l
 }
 
 // Push adds an item to the stack
 func (s *Stack) Push(item interface{}) {
+	s.rwmu.Lock()
 	s.items = append(s.items, item)
+	s.rwmu.Unlock()
 }
 
 // Pop removes the top item from the stack and returns it
 func (s *Stack) Pop() (interface{}, bool) {
-	b, l := s.IsEmpty()
-	l = l - 1
+	item := interface{}(nil)
 
-	if !b {
-		item := s.items[l]
-		s.items = s.items[:l]
-		return item, true
+	if e, _ := s.IsEmpty(); e {
+		return item, false
 	}
 
-	return 0, false
+	s.rwmu.Lock()
 
+	last := len(s.items) - 1
+	if last >= 0 {
+		item = s.items[last]
+		s.items = s.items[:last]
+	}
+
+	defer s.rwmu.Unlock()
+
+	return item, true
 }
 
 // Peek returns the top item without removing it
 func (s *Stack) Peek() (interface{}, bool) {
-	b, l := s.IsEmpty()
+	item := interface{}(nil)
+	e, last := s.IsEmpty()
 
-	if !b {
-		item := s.items[l-1]
-		return item, true
+	if e {
+		return item, false
 	}
 
-	return 0, false
+	last = last - 1
+	if last >= 0 {
+		s.rwmu.RLock()
+		item = s.items[last]
+		s.rwmu.RUnlock()
+	}
+
+	return item, true
 }
 
 func main() {
@@ -61,7 +86,7 @@ func main() {
 
 	item, ok = myStack.Peek()
 	if ok {
-		fmt.Printf("Peek item: %v \n", item)
+		fmt.Printf("Peeked item: %v \n", item)
 	}
 
 	fmt.Printf("stack: %v", myStack)

--- a/stack_test.go
+++ b/stack_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"sync"
 	"testing"
 )
 
@@ -17,7 +18,7 @@ func Test_Push(t *testing.T) {
 	got := len(stack.items)
 
 	// Assert
-	assert(t, got, want)
+	assertEqual(t, got, want)
 }
 
 func Test_Pop(t *testing.T) {
@@ -33,13 +34,38 @@ func Test_Pop(t *testing.T) {
 	item, ok := stack.Pop()
 	if ok {
 		t.Logf("Removed top element: %v", item)
-	}else{
+	} else {
 		t.Fatalf("Unexpected error, stack is empty")
 	}
 	got := len(stack.items)
 
 	// Assert
-	assert(t, got, want)
+	assertEqual(t, got, want)
+}
+
+func Test_Pop_Until_Empty(t *testing.T) {
+	// Arrange
+	stack := Stack{}
+	stack.Push(1)
+	stack.Push(2)
+	stack.Push(3)
+	t.Logf("Pushed 3 elementes in Stack: %v", stack.items)
+	want := 0
+	l := len(stack.items)
+
+	// Act
+	for i := 0; i < l; i++ {
+		item, ok := stack.Pop()
+		if ok {
+			t.Logf("Removed top element: %v", item)
+		} else {
+			t.Fatalf("Unexpected error, stack is empty")
+		}
+	}
+	got := len(stack.items)
+
+	// Assert
+	assertEqual(t, got, want)
 }
 
 func Test_Peek(t *testing.T) {
@@ -55,13 +81,30 @@ func Test_Peek(t *testing.T) {
 	item, ok := stack.Peek()
 	if ok {
 		t.Logf("Peeked last element: %v", item)
-	}else{
+	} else {
 		t.Fatalf("Unexpected error, stack is empty")
 	}
 	got := len(stack.items)
 
 	// Assert
-	assert(t, got, want)
+	assertEqual(t, got, want)
+}
+
+func Test_Peek_When_Empty(t *testing.T) {
+	// Arrange
+	stack := Stack{}
+	t.Logf("Stack is empty: %v", stack.items)
+	want := 0
+
+	// Act
+	item, ok := stack.Peek()
+	if !ok {
+		t.Logf("Unable to peek, stack is empty: %v", item)
+	}
+	got := len(stack.items)
+
+	// Assert
+	assertEqual(t, got, want)
 }
 
 func Test_If_Empty(t *testing.T) {
@@ -69,24 +112,80 @@ func Test_If_Empty(t *testing.T) {
 	stack := Stack{}
 	stack.Push(1)
 	t.Logf("Pushed 1 elementes in Stack: %v", stack.items)
-	want := true
+	want := 0
 
 	// Act
 	item, ok := stack.Pop()
 	if ok {
 		t.Logf("Peeked last element: %v", item)
-	}else{
+	} else {
 		t.Fatalf("Unexpected error, stack is empty")
 	}
 	_, got := stack.IsEmpty()
 
 	// Assert
-	assert(t, got, want)
+	assertEqual(t, got, want)
 }
 
-func assert(t *testing.T, got, want interface{}) {
+func Test_Concurrently_Push(t *testing.T) {
+	// Arrange
+	stack := Stack{}
+	want := 12
+	wg := sync.WaitGroup{}
+
+	// Act
+	for i := 0; i < 12; i++ {
+		wg.Add(1)
+		go func() {
+			stack.Push(i)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	t.Logf("Pushed 12 elementes in Stack: %v", stack.items)
+	got := len(stack.items)
+
+	// Assert
+	assertEqual(t, got, want)
+}
+
+func Test_Pop_Concurrently(t *testing.T) {
+	// Arrange
+	stack := Stack{}
+	want := 0
+	wg := sync.WaitGroup{}
+	max := 12
+	for i := 0; i < max; i++ {
+		wg.Add(1)
+		go func() {
+			stack.Push(i)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	// Act
+	for j := 0; j < max; j++ {
+		wg.Add(1)
+		go func() {
+			stack.Pop()
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	t.Logf("Popped 12 elementes, in stack: %v", stack.items)
+	got := len(stack.items)
+
+	// Assert
+	assertEqual(t, got, want)
+}
+
+func assertEqual(t *testing.T, got, want interface{}) {
 	if got != want {
 		t.Errorf("Expected %v but got %v", want, got)
+		return
 	}
 
 	t.Logf("Expected %v, got %v", want, got)


### PR DESCRIPTION
## Summary of changes:

- Added control for internal read/write collection, now is concurrently safe.
- Added new unit tests cases.

## Why this feature is needed?

Symptom:

Last version experienced race conditions when it ran on goroutines, if we ran `go test -v -r` we got something like: 

```
==================
WARNING: DATA RACE
Write at 0x00c000210048 by goroutine 25:
  stack-in-go-code-challenge.(*Stack).Push()
```

## Solution:

Used read/write mutex,  `sync.RWMutex` struct, to locking read and write internal collection.

